### PR TITLE
Fix target position

### DIFF
--- a/Assets/Scripts/Tower/Bullet.cs
+++ b/Assets/Scripts/Tower/Bullet.cs
@@ -18,7 +18,7 @@ namespace Tower
 
         public void Shoot(Transform target, float speed, float damage, float range = 0)
         {
-            _targetPosition = target.position;
+            _targetPosition = getTargetPosition(target);
             _speed = speed;
             _damage = damage;
             _range = range;
@@ -47,6 +47,17 @@ namespace Tower
             // heavy mode
             else if (_range != 0)
                 Detonation();
+        }
+
+        private Vector3 getTargetPosition(Transform target)
+        {
+            var targetPosition = target.position;
+
+            return new Vector3(
+                targetPosition.x,
+                targetPosition.y - target.localScale.y / 2,
+                targetPosition.z
+            );
         }
 
         private void Detonation()


### PR DESCRIPTION
The bullet was not destroyed when it touched the ground because it did not actually touch the ground.
This happens because the target position of the bullet coincides with the barycentre of the enemy and not with the ground.
This PR solve this issue.

To notice this issue you have to lower the speed of the bullet e.g. to 10.